### PR TITLE
Binyamin/support hash and reverse methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Extypes stands for extensible types, a Python package that enables extending typ
   - [x] Number protocol
   - [x] Mapping protocol
   - [x] Sequence protocol
-- [ ] Add support for reverse methods (e.g. `__radd__`)
+- [x] Add support for reverse methods (e.g. `__radd__`)
 - [x] Make this features/todo list look nicer
+- [ ] Add support for the rich comparison function
 
 
 ## Build & Installation

--- a/src/extypes/extypes.cpp
+++ b/src/extypes/extypes.cpp
@@ -152,7 +152,10 @@ static PyObject *impl__getitem__(PyObject *self, PyObject *item)
 
 static int impl__setitem__(PyObject *self, PyObject *item, PyObject *value)
 {
-    return PyNumber_AsSsize_t(PyObject_Call(PyObject_GetAttrString(self, "__setitem__"), PyTuple_Pack(0), NULL), NULL);
+    if (value == NULL) {
+        return PyNumber_AsSsize_t(PyObject_Call(PyObject_GetAttrString(self, "__delitem__"), PyTuple_Pack(1, item), NULL), NULL);
+    }
+    return PyNumber_AsSsize_t(PyObject_Call(PyObject_GetAttrString(self, "__setitem__"), PyTuple_Pack(2, item, value), NULL), NULL);
 }
 
 // Special methods

--- a/src/extypes/extypes.cpp
+++ b/src/extypes/extypes.cpp
@@ -170,6 +170,9 @@ static PyObject *impl__call__(PyObject *self, PyObject *args, PyObject *kwargs)
 // static Py_hash_t impl__hash__(PyObject* self) {
 
 // }
+static Py_hash_t impl__hash__(PyObject* self) {
+    return PyLong_AsSsize_t(PyObject_Call(PyObject_GetAttrString(self, "__hash__"), PyTuple_Pack(0), NULL));
+}
 
 static PyObject *impl__str__(PyObject *self)
 {
@@ -404,7 +407,7 @@ static MagicMethodLookupResult get_magic_method_implementation(char const *name_
     IMPL(__call__)
     if (name == "__hash__")
     {
-        return NOT_IMPLEMENTED;
+        return impl__hash__;
     }
     IMPL(__str__)
     if (name == "__getattr__")

--- a/src/extypes/extypes.cpp
+++ b/src/extypes/extypes.cpp
@@ -167,11 +167,8 @@ static PyObject *impl__call__(PyObject *self, PyObject *args, PyObject *kwargs)
     return PyObject_Call(PyObject_GetAttrString(self, "__call__"), args, kwargs);
 }
 
-// static Py_hash_t impl__hash__(PyObject* self) {
-
-// }
 static Py_hash_t impl__hash__(PyObject* self) {
-    return PyNumber_AsSsize_t(PyObject_Call(PyObject_GetAttrString(self, "__hash__"), PyTuple_Pack(0), NULL));
+    return PyNumber_AsSsize_t(PyObject_Call(PyObject_GetAttrString(self, "__hash__"), PyTuple_Pack(0), NULL), NULL);
 }
 
 static PyObject *impl__str__(PyObject *self)

--- a/src/extypes/extypes.cpp
+++ b/src/extypes/extypes.cpp
@@ -171,7 +171,7 @@ static PyObject *impl__call__(PyObject *self, PyObject *args, PyObject *kwargs)
 
 // }
 static Py_hash_t impl__hash__(PyObject* self) {
-    return PyLong_AsSsize_t(PyObject_Call(PyObject_GetAttrString(self, "__hash__"), PyTuple_Pack(0), NULL));
+    return PyNumber_AsSsize_t(PyObject_Call(PyObject_GetAttrString(self, "__hash__"), PyTuple_Pack(0), NULL));
 }
 
 static PyObject *impl__str__(PyObject *self)

--- a/src/extypes/extypes.cpp
+++ b/src/extypes/extypes.cpp
@@ -47,8 +47,8 @@ static constexpr uint32_t NOT_IMPLEMENTED = 2U;
 
 // Implementations
 
-#define UNARY_OP(name)                                                                    \
-    static PyObject *impl##name(PyObject *self)                                           \
+#define UNARY_OP_IMPL(name)                                                               \
+    static PyObject *impl##name##(PyObject * self)                                        \
     {                                                                                     \
         if (!PyObject_HasAttrString(self, #name))                                         \
         {                                                                                 \
@@ -57,7 +57,9 @@ static constexpr uint32_t NOT_IMPLEMENTED = 2U;
         return PyObject_Call(PyObject_GetAttrString(self, #name), PyTuple_Pack(0), NULL); \
     }
 
-#define BINARY_OP(name)                                                                          \
+#define UNARY_OP(name) UNARY_OP_IMPL(__##name##__)
+
+#define BINARY_OP_IMPL(name)                                                                     \
     static PyObject *impl##name(PyObject *left, PyObject *right)                                 \
     {                                                                                            \
         if (!PyObject_HasAttrString(left, #name))                                                \
@@ -67,7 +69,24 @@ static constexpr uint32_t NOT_IMPLEMENTED = 2U;
         return PyObject_Call(PyObject_GetAttrString(left, #name), PyTuple_Pack(1, right), NULL); \
     }
 
-#define TERNARY_OP(name)                                                                               \
+#define BINARY_OP(name) BINARY_OP_IMPL(__##name##__)
+
+#define _RBINARY_OP_IMPL(name, rname)                                                                     \
+    static PyObject *impl##name##(PyObject * left, PyObject * right)                                      \
+    {                                                                                                     \
+        if (!PyObject_HasAttrString(left, #name))                                                         \
+        {                                                                                                 \
+            if (!PyObject_HasAttrString(right, #rname))                                                   \
+                Py_RETURN_NOTIMPLEMENTED;                                                                 \
+            else                                                                                          \
+                return PyObject_Call(PyObject_GetAttrString(right, #rname), PyTuple_Pack(1, left), NULL); \
+        }                                                                                                 \
+        return PyObject_Call(PyObject_GetAttrString(left, #name), PyTuple_Pack(1, right), NULL);          \
+    }
+
+#define RBINARY_OP(name) _RBINARY_OP_IMPL(__##name##__, __r##name##__)
+
+#define TERNARY_OP_IMPL(name)                                                                          \
     static PyObject *impl##name(PyObject *self, PyObject *left, PyObject *right)                       \
     {                                                                                                  \
         if (!PyObject_HasAttrString(self, #name))                                                      \
@@ -77,17 +96,20 @@ static constexpr uint32_t NOT_IMPLEMENTED = 2U;
         return PyObject_Call(PyObject_GetAttrString(self, #name), PyTuple_Pack(2, left, right), NULL); \
     }
 
+#define TERNARY_OP(name) TERNARY_OP_IMPL(__##name##__)
+
 // Number protocol
 
-BINARY_OP(__add__)
-BINARY_OP(__sub__)
-BINARY_OP(__mul__)
-BINARY_OP(__mod__)
-BINARY_OP(__divmod__)
-TERNARY_OP(__pow__)
-UNARY_OP(__neg__)
-UNARY_OP(__pos__)
-UNARY_OP(__abs__)
+RBINARY_OP(add)
+RBINARY_OP(sub)
+RBINARY_OP(mul)
+RBINARY_OP(mod)
+RBINARY_OP(divmod)
+TERNARY_OP(pow)
+BINARY_OP(rpow)
+UNARY_OP(neg)
+UNARY_OP(pos)
+UNARY_OP(abs)
 
 static int impl__bool__(PyObject *self)
 {
@@ -103,35 +125,35 @@ static int impl__bool__(PyObject *self)
     return PyObject_IsTrue(PyObject_Call(PyObject_GetAttrString(self, "__bool__"), PyTuple_Pack(0), NULL));
 }
 
-UNARY_OP(__invert__)
-BINARY_OP(__shl__)
-BINARY_OP(__shr__)
-BINARY_OP(__and__)
-BINARY_OP(__xor__)
-BINARY_OP(__or__)
-UNARY_OP(__int__)
-UNARY_OP(__float__)
+UNARY_OP(invert)
+RBINARY_OP(lshift)
+RBINARY_OP(rshift)
+RBINARY_OP(and)
+RBINARY_OP(xor)
+RBINARY_OP(or)
+UNARY_OP(int)
+UNARY_OP(float)
 
-BINARY_OP(__iadd__)
-BINARY_OP(__isub__)
-BINARY_OP(__imul__)
-BINARY_OP(__imod__)
-TERNARY_OP(__ipow__)
-BINARY_OP(__ishl__)
-BINARY_OP(__ishr__)
-BINARY_OP(__iand__)
-BINARY_OP(__ixor__)
-BINARY_OP(__ior__)
+BINARY_OP(iadd)
+BINARY_OP(isub)
+BINARY_OP(imul)
+BINARY_OP(imod)
+TERNARY_OP(ipow)
+BINARY_OP(ilshift)
+BINARY_OP(irshift)
+BINARY_OP(iand)
+BINARY_OP(ixor)
+BINARY_OP(ior)
 
-BINARY_OP(__floordiv__)
-BINARY_OP(__truediv__)
-BINARY_OP(__ifloordiv__)
-BINARY_OP(__itruediv__)
+RBINARY_OP(floordiv)
+RBINARY_OP(truediv)
+BINARY_OP(ifloordiv)
+BINARY_OP(itruediv)
 
-BINARY_OP(__index__)
+BINARY_OP(index)
 
-BINARY_OP(__matmul__)
-BINARY_OP(__imatmul__)
+RBINARY_OP(matmul)
+BINARY_OP(imatmul)
 
 // End number protocol
 
@@ -397,19 +419,18 @@ static MagicMethodLookupResult get_magic_method_implementation(char const *name_
 {
     std::string name{name_str};
 
-#define IMPL(method_name)         \
-    if (name == #method_name)     \
-    {                             \
+#define _IMPL(method_name) \
+    if (name == #method_name) \
+    {\
         return impl##method_name; \
     }
 
-    IMPL(__repr__)
-    IMPL(__call__)
-    if (name == "__hash__")
-    {
-        return impl__hash__;
-    }
-    IMPL(__str__)
+#define IMPL(method_name) _IMPL(__##method_name##__)
+
+    IMPL(repr)
+    IMPL(call)
+    IMPL(hash)
+    IMPL(str)
     if (name == "__getattr__")
     {
         return PyObject_GenericGetAttr;
@@ -418,57 +439,58 @@ static MagicMethodLookupResult get_magic_method_implementation(char const *name_
     {
         return PyObject_GenericSetAttr;
     }
-    IMPL(__iter__)
-    IMPL(__next__)
+    IMPL(iter)
+    IMPL(next)
 
-    IMPL(__len__)
-    IMPL(__contains__)
-    IMPL(__getitem__)
-    IMPL(__setitem__)
+    IMPL(len)
+    IMPL(contains)
+    IMPL(getitem)
+    IMPL(setitem)
 
-    IMPL(__add__)
-    IMPL(__sub__)
-    IMPL(__mul__)
-    IMPL(__mod__)
-    IMPL(__divmod__)
-    IMPL(__pow__)
-    IMPL(__neg__)
-    IMPL(__pos__)
-    IMPL(__abs__)
+    IMPL(add)
+    IMPL(sub)
+    IMPL(mul)
+    IMPL(mod)
+    IMPL(divmod)
+    IMPL(pow)
+    IMPL(neg)
+    IMPL(pos)
+    IMPL(abs)
 
-    IMPL(__bool__)
+    IMPL(bool)
 
-    IMPL(__invert__)
-    IMPL(__shl__)
-    IMPL(__shr__)
-    IMPL(__and__)
-    IMPL(__xor__)
-    IMPL(__or__)
-    IMPL(__int__)
-    IMPL(__float__)
+    IMPL(invert)
+    IMPL(lshift)
+    IMPL(rshift)
+    IMPL(and)
+    IMPL(xor)
+    IMPL(or)
+    IMPL(int)
+    IMPL(float)
 
-    IMPL(__iadd__)
-    IMPL(__isub__)
-    IMPL(__imul__)
-    IMPL(__imod__)
-    IMPL(__ipow__)
-    IMPL(__ishl__)
-    IMPL(__ishr__)
-    IMPL(__iand__)
-    IMPL(__ixor__)
-    IMPL(__ior__)
+    IMPL(iadd)
+    IMPL(isub)
+    IMPL(imul)
+    IMPL(imod)
+    IMPL(ipow)
+    IMPL(ilshift)
+    IMPL(irshift)
+    IMPL(iand)
+    IMPL(ixor)
+    IMPL(ior)
 
-    IMPL(__floordiv__)
-    IMPL(__truediv__)
-    IMPL(__ifloordiv__)
-    IMPL(__itruediv__)
+    IMPL(floordiv)
+    IMPL(truediv)
+    IMPL(ifloordiv)
+    IMPL(itruediv)
 
-    IMPL(__index__)
+    IMPL(index)
 
-    IMPL(__matmul__)
-    IMPL(__imatmul__)
+    IMPL(matmul)
+    IMPL(imatmul)
 
 #undef IMPL
+#undef _IMPL
 
     return INVALID_MAGIC_METHOD;
 }


### PR DESCRIPTION
I have implemented reverse magic methods, but you have to first override the regular method for it to work.

For example, let's say I want to do `O + tuple`,  so I'd want to implement it on the tuple.
```py
class TupleExtensions(tuple):
  @extension
  def  __radd__(self, other):
    return tuple(other + item for item in self)
```

This will only work if the `__add__` method is programmed to return `NotImplemented` when the types don't match.
However, this is not usually the case and it'll usually just throw a `TypeError`. We can think about how to overcome this
issue later.

Anyway, what you'd have to do is this (e.g. for integers):
```py
class IntExt:
  __int_add__ = int.__add__  # since we're overriding the original one
  
  @extension
  def __add__(self, other):
    try:
      return IntExt.__int_add__(self, other)
    except TypeError:
      return NotImplemented
```

Now this will work:
```
>>> 1 + (3, 4)
(4, 5)
```

but you'll have to do it for each type.

---

We can "fix" this by, instead of only calling the reverse method when the result is `NotImplemented`, calling it also when there's
a `TypeError` exception. But, we should really think this through.